### PR TITLE
replace db.driver with db.checkout for supporting latest crystal-sqlite3 changes

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,0 +1,5 @@
+Lint/SpecFilename:
+  Excluded:
+    - spec/migration/*
+Naming/BlockParameterName:
+  Enabled: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: apk add --no-cache sqlite-dev rsync
+        run: sudo apt-get install -y libsqlite3-dev rsync
 
       - name: Install shards
         run: shards install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,22 @@ on:
     types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
 
 jobs:
-  build:
+  build-apk:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal:1.0.0-alpine
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install system dependencies
+      run: apk add --no-cache sqlite-dev rsync
+    - name: Install shards
+      run: shards install
+    - name: Test
+      run: crystal spec
+    - name: Ameba
+      run: ./bin/ameba
+
+  build-on-ubuntu:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,20 +4,37 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
-    container:
-      image: crystallang/crystal:1.0.0-alpine
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        crystal: [1.0.0, latest, nightly]
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Install system dependencies
-      run: apk add --no-cache sqlite-dev rsync
-    - name: Install shards
-      run: shards install
-    - name: Test
-      run: crystal spec
-    - name: Ameba
-      run: ./bin/ameba
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+
+      - name: Download source
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: apk add --no-cache sqlite-dev rsync
+
+      - name: Install shards
+        run: shards install
+
+      - name: Test
+        run: crystal spec
+
+      - name: Check formatting
+        run: crystal tool format; git diff --exit-code
+        if: matrix.crystal == 'latest' && matrix.os == 'ubuntu-latest'
+
+      - name: Ameba
+        run: ./bin/ameba

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        crystal: [1.0.0, latest, nightly]
+        crystal: [1.0.0, latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Crystal

--- a/shard.yml
+++ b/shard.yml
@@ -1,10 +1,11 @@
 name: mg
-version: 0.5.0
+version: 0.6.0
 
 authors:
   - Alex Ling <email@hkalexling.com>
+  - Sandeep Rao
 
-crystal: 1.0.0
+crystal: ">= 1.0.0, < 2.0.0"
 
 license: MIT
 

--- a/spec/mg_spec.cr
+++ b/spec/mg_spec.cr
@@ -152,7 +152,7 @@ describe MG do
         after_down_time = Time.unix_ms(lc[:after_down])
 
         # Count no more than: down + down + after_down
-        count.should eq (prev_count + 3)
+        count.should eq(prev_count + 3)
 
         # Test the execution order
         # We have only the first migration with a lifecyle

--- a/src/mg/base.cr
+++ b/src/mg/base.cr
@@ -43,11 +43,11 @@ module MG
           ver = __FILE__.match(/^.+\.([0-9]+)\.cr$/).not_nil![1].to_i
         rescue
           raise MG::FilenameError.new "The filename #{__FILE__} does not " \
-              "contain a valid version number"
+                                      "contain a valid version number"
         end
         unless ver > 0
           raise MG::FilenameError.new "Version number must be non-negative, " \
-            "but we found #{ver} in #{__FILE__}"
+                                      "but we found #{ver} in #{__FILE__}"
         end
         ver
       end

--- a/src/mg/migration.cr
+++ b/src/mg/migration.cr
@@ -42,11 +42,13 @@ module MG
     end
 
     private def next_version(ver : Int32)
-      versions.find &.version.> ver
+      next_version = versions.find &.version.> ver
+      next_version || raise(VersionError.new "No next version found")
     end
 
     private def prev_version(ver : Int32)
-      versions.reverse.find &.version.< ver
+      prev_version = versions.reverse.find &.version.< ver
+      prev_version || raise(VersionError.new "No previous version found")
     end
 
     # :nodoc:
@@ -95,7 +97,7 @@ module MG
 
     # Returns true if the connection uses SQLite driver, false otherwise.
     private def sqlite? : Bool
-      @db.driver.class.to_s == "SQLite3::Driver"
+      @db.checkout.class.to_s == "SQLite3::Connection"
     end
 
     private def check_version(to : Int32)
@@ -117,9 +119,9 @@ module MG
         end
 
         target = if is_up
-                   next_version(user_version).not_nil!
+                   next_version(user_version)
                  else
-                   prev_version(user_version).not_nil!
+                   prev_version(user_version)
                  end
 
         log.info { "Migrating to #{target.name} (#{target.version})" }


### PR DESCRIPTION
Replace deprecated db.driver with db.checkout based on latest `crystal-sqlite3` library